### PR TITLE
Added mruby_handler requirements for h2o-2.1.0

### DIFF
--- a/src/debian/h2o.install
+++ b/src/debian/h2o.install
@@ -8,3 +8,10 @@ usr/share/h2o/setuidgid
 usr/share/h2o/start_server
 usr/share/h2o/ca-bundle.crt
 usr/share/h2o/status/index.html
+usr/share/h2o/mruby/acl.rb
+usr/share/h2o/mruby/bootstrap.rb
+usr/share/h2o/mruby/dos_detector.rb
+usr/share/h2o/mruby/htpasswd.rb
+usr/share/h2o/mruby/lru_cache.rb
+usr/share/h2o/mruby/preloads.rb
+usr/share/h2o/mruby/trie_addr.rb


### PR DESCRIPTION
Hi, I got h2o bootstrap failure after 2.1.0 upgrading from 2.0.5. It caused that h2o-2.1.0 didn't contain mruby support files for `mruby_handler`

I added requirements of `mruby_handler` from h2o source files.