### PR TITLE
Fix sysvinit script crash and not working, fixed #8

### DIFF
--- a/src/debian/h2o.default
+++ b/src/debian/h2o.default
@@ -6,4 +6,4 @@
 # This is a POSIX shell fragment
 #
 
-#CONFIG_FILE="/etc/h2o/h2o.conf"
+#CONFIG="/etc/h2o/h2o.conf"

--- a/src/debian/h2o.init
+++ b/src/debian/h2o.init
@@ -18,7 +18,7 @@
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC="optimized HTTP/1 HTTP/2 server"
 NAME=h2o
-CONFIG_FILE=/etc/h2o/h2o.conf
+CONFIG=/etc/h2o/h2o.conf
 DAEMON=/usr/sbin/h2o
 SCRIPTNAME=/etc/init.d/$NAME
 
@@ -28,10 +28,10 @@ SCRIPTNAME=/etc/init.d/$NAME
 # Read configuration variable file if it is present
 [ -r /etc/default/$NAME ] && . /etc/default/$NAME
 
-DAEMON_ARGS="-m daemon -c $CONFIG_FILE"
-PIDFILE=`sed -ne 's|pid-file:\s*\([-_./0-9a-zA-Z]\{1,\}\)|\1|p' $CONFIG_FILE`
+DAEMON_ARGS="-m daemon -c $CONFIG"
+PIDFILE=`sed -ne 's|pid-file:\s*\([-_./0-9a-zA-Z]\{1,\}\)|\1|p' $CONFIG`
 if [ -z "$PIDFILE" ]; then
-	echo "pid-file must be defined in $CONFIG_FILE"
+	echo "pid-file must be defined in $CONFIG"
 	exit 1
 fi
 
@@ -88,7 +88,7 @@ do_stop()
 # Function that checks the daemon/service configuration file
 #
 do_configtest() {
-	$DAEMON -t -c $CONFIG_TEST
+	$DAEMON -t -c $CONFIG
 }
 
 #
@@ -97,26 +97,26 @@ do_configtest() {
 do_reload() {
 	# as the running h2o is started by a perl process, (from the start_server) 
 	# so the perl process is the real program to send the signal:
-        log_daemon_msg "Reloading $DESC configuration files" "$NAME"
         start-stop-daemon --oknodo --stop --signal HUP --quiet --pidfile "$PIDFILE" --exec "/usr/bin/perl"
-        log_end_msg $?
+        return "$?"
 }
 
 case "$1" in
   start)
-	[ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
+	log_daemon_msg "Starting $DESC"
 	do_start
 	case "$?" in
-		0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
-		2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+		0|1) log_end_msg 0 ;;
+		2) log_end_msg 1 ;;
 	esac
 	;;
   stop)
-	[ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
+	log_daemon_msg "Stopping $DESC"
 	do_stop
 	case "$?" in
-		0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
-		2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+		0|1) log_end_msg 0 ;;
+		2) log_end_msg 1 ;;
+		*) log_end_msg 0 ;;
 	esac
 	;;
   status)
@@ -127,7 +127,7 @@ case "$1" in
 	# If do_reload() is not implemented then leave this commented out
 	# and leave 'force-reload' as an alias for 'restart'.
 	#
-	log_daemon_msg "Reloading $DESC" "$NAME"
+	log_daemon_msg "Reloading $DESC"
 	if ! do_configtest >/dev/null 2>&1; then
 		log_end_msg 1 # Configuration error
 		exit 0
@@ -140,13 +140,13 @@ case "$1" in
 	# If the "reload" option is implemented then remove the
 	# 'force-reload' alias
 	#
-	log_daemon_msg "Restarting $DESC" "$NAME"
+	log_daemon_msg "Restarting $DESC"
 	do_stop
 	case "$?" in
 	  0|1)
 		do_start
 		case "$?" in
-			0) log_end_msg 0 ;;
+			0) log_end_msg 0;;
 			1) log_end_msg 1 ;; # Old process is still running
 			*) log_end_msg 1 ;; # Failed to start
 		esac

--- a/src/debian/h2o.init
+++ b/src/debian/h2o.init
@@ -10,7 +10,7 @@
 #                    server.
 ### END INIT INFO
 
-# Author: Tatsushi Demachi <tdemachi@gmail.com>
+# Author: PICCORO Lenz McKAY <mckaygerhard@gmail.com>
 
 # Do NOT "set -e"
 

--- a/src/debian/h2o.init
+++ b/src/debian/h2o.init
@@ -120,7 +120,7 @@ case "$1" in
 	esac
 	;;
   status)
-	status_of_proc "$DAEMON" "$NAME" && exit 0 || exit $?
+	status_of_proc ${PIDFILE:+-p ${PIDFILE}} /usr/bin/perl h2o && exit 0 || exit $?
 	;;
   reload|force-reload)
 	#

--- a/src/debian/h2o.init
+++ b/src/debian/h2o.init
@@ -5,8 +5,9 @@
 # Required-Stop:     $local_fs $network $remote_fs $syslog
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
-# Short-Description: start and stop h2o HTTP Server
-# Description:       H2O - the optimized HTTP/1, HTTP/2 server
+# Short-Description: Optimized HTTP/1.x, HTTP/2 server
+# Description:       Manages the h2o daemon, the optimized HTTP/1.x and HTTP/2
+#                    server.
 ### END INIT INFO
 
 # Author: Tatsushi Demachi <tdemachi@gmail.com>
@@ -15,7 +16,7 @@
 
 # PATH should only include /usr/* if it runs after the mountnfs.sh script
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
-DESC="h2o"
+DESC="optimized HTTP/1 HTTP/2 server"
 NAME=h2o
 CONFIG_FILE=/etc/h2o/h2o.conf
 DAEMON=/usr/sbin/h2o
@@ -47,7 +48,7 @@ fi
 #
 do_start()
 {
-	# Return
+	# the real daemon start by a perl implementation so we trap the return as:
 	#   0 if daemon has been started
 	#   1 if daemon was already running
 	#   2 if daemon could not be started
@@ -56,18 +57,6 @@ do_start()
 	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON -- \
 		$DAEMON_ARGS \
 		|| return 2
-	# The above code will not work for interpreted scripts, use the next
-	# six lines below instead (Ref: #643337, start-stop-daemon(8) )
-	#start-stop-daemon --start --quiet --pidfile $PIDFILE --startas $DAEMON \
-	#	--name $NAME --test > /dev/null \
-	#	|| return 1
-	#start-stop-daemon --start --quiet --pidfile $PIDFILE --startas $DAEMON \
-	#	--name $NAME -- $DAEMON_ARGS \
-	#	|| return 2
-
-	# Add code here, if necessary, that waits for the process to be ready
-	# to handle requests from services started subsequently which depend
-	# on this one.  As a last resort, sleep for some time.
 }
 
 #
@@ -75,12 +64,11 @@ do_start()
 #
 do_stop()
 {
-	# Return
-	#   0 if daemon has been stopped
-	#   1 if daemon was already stopped
-	#   2 if daemon could not be stopped
-	#   other if a failure occurred
-	start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE --name $NAME
+	# the starting of the server is xplained here https://github.com/h2o/h2o/issues/84#issuecomment-68315426
+	# is a perl process in fact..  is a set of superdaemon program (named start_server) 
+	# and a support library written in Perl, for hot-deploying TCP servers, 
+	# so the perl process is the real program to kill but only with pid reported by h2o:
+	start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE --exec /usr/bin/perl
 	RETVAL="$?"
 	[ "$RETVAL" = 2 ] && return 2
 	# Wait for children to finish too if this is a daemon that forks
@@ -89,7 +77,7 @@ do_stop()
 	# that waits for the process to drop all resources that could be
 	# needed by services started subsequently.  A last resort is to
 	# sleep for some time.
-	start-stop-daemon --stop --quiet --oknodo --retry=0/30/KILL/5 --exec $DAEMON
+	start-stop-daemon --stop --quiet --oknodo --retry=0/30/KILL/5 --pidfile $PIDFILE --exec /usr/bin/perl
 	[ "$?" = 2 ] && return 2
 	# Many daemons don't delete their pidfiles when they exit.
 	rm -f $PIDFILE
@@ -107,13 +95,11 @@ do_configtest() {
 # Function that sends a SIGHUP to the daemon/service
 #
 do_reload() {
-	#
-	# If the daemon can reload its configuration without
-	# restarting (for example, when it is sent a SIGHUP),
-	# then implement that here.
-	#
-	start-stop-daemon --stop --signal 1 --quiet --pidfile $PIDFILE --name $NAME
-	return 0
+	# as the running h2o is started by a perl process, (from the start_server) 
+	# so the perl process is the real program to send the signal:
+        log_daemon_msg "Reloading $DESC configuration files" "$NAME"
+        start-stop-daemon --oknodo --stop --signal HUP --quiet --pidfile "$PIDFILE" --exec "/usr/bin/perl"
+        log_end_msg $?
 }
 
 case "$1" in
@@ -177,7 +163,6 @@ case "$1" in
 	log_end_msg $?
 	;;
   *)
-	#echo "Usage: $SCRIPTNAME {start|stop|restart|reload|force-reload}" >&2
 	echo "Usage: $SCRIPTNAME {start|stop|status|restart|reload|force-reload|configtest}" >&2
 	exit 3
 	;;

--- a/src/debian/h2o.service
+++ b/src/debian/h2o.service
@@ -1,10 +1,15 @@
 [Unit]
-Description=H2O - the optimized HTTP/1, HTTP/2 server
+Description=Powered HTTP/1.x, HTTP/2 server
+Documentation=man:h2o(1)
+Documentation=file:/usr/share/doc/h2o-doc/index.html
+Documentation=https://h2o.examp1e.net
 After=network.target remote-fs.target nss-lookup.target
 
 [Service]
 Type=simple
-ExecStart=/usr/sbin/h2o -m master -c /etc/h2o/h2o.conf
+Environment=CONFIG=/etc/h2o/h2o.conf
+EnvironmentFile=-/etc/default/h2o
+ExecStart=/usr/bin/h2o -c ${CONFIG} -m master
 ExecReload=/bin/kill -HUP ${MAINPID}
 ExecStop=/bin/kill -TERM ${MAINPID}
 PrivateTmp=true


### PR DESCRIPTION
* Fix sysvinit script crash and not working, fixed #8 , 
  the real process is a perl process as xplained in
  https://github.com/h2o/h2o/issues/84#issuecomment-68315426
  so we need to point in the start-and-stop-daemon to property
  managed.. so in init scritp is commented and fixed the functions
* starts a set of superdaemon program (named start_server) and a
  support library written in Perl, for hot-deploying TCP servers
  so the provided init script does nothing cos does not point real process